### PR TITLE
Fix for building and uploading firmware to ATmega devices via arduino-mk and avrdude 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,4 @@ basedeps:
 	dpkg-checkbuilddeps
 
 .PHONY: install build clean zip bb basedeps
+	

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -2,6 +2,7 @@
 # vim: set foldmethod=marker :
 # Copyright 2014-2016 Michigan Technological University
 # Copyright 2016 Bas Wijnen <wijnen@debian.org>
+# Copyright 2017 Lorin Edwin Parker <lorin.parker@hive13.org>
 # Author: Bas Wijnen <wijnen@debian.org>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -43,6 +44,7 @@ else
 OPTIMIZATION_LEVEL = 1
 CPPFLAGS += -DARCH_INCLUDE=\"arch-avr.h\" -DWATCHDOG
 ARDUINO_LIBS = EEPROM
+AVRDUDE_CONF = /etc/avrdude.conf
 
 # To avoid loading HardwareSerial.cpp, disable the core.
 NO_CORE = true
@@ -67,32 +69,44 @@ ifeq (${TARGET}, atmega328p)
 BOARD_TAG = uno
 CPPFLAGS += -DNUM_MOTORS=3 -DFRAGMENTS_PER_MOTOR_BITS=3 -DBYTES_PER_FRAGMENT=8 -DSERIAL_SIZE_BITS=9
 CPPFLAGS += -DUSART0_RX_vect=USART_RX_vect -DNO_DEBUG
+AVRDUDE_OPTS = -q -q -D
+
 else
 ifeq (${TARGET}, atmega1284p)
 BOARD_TAG = mighty_opt
 ARDUINO_VAR_PATH = /usr/share/arduino/hardware/mighty-1284p/variants
 BOARDS_TXT = /usr/share/arduino/hardware/mighty-1284p/boards.txt
 CPPFLAGS += -DNUM_MOTORS=10 -DFRAGMENTS_PER_MOTOR_BITS=5 -DBYTES_PER_FRAGMENT=32 -DSERIAL_SIZE_BITS=10
+AVRDUDE_OPTS = -q -q -D
+
 else
 ifeq (${TARGET}, atmega1280)
 BOARD_TAG = mega
 CPPFLAGS += -DNUM_MOTORS=10 -DFRAGMENTS_PER_MOTOR_BITS=4 -DBYTES_PER_FRAGMENT=16 -DSERIAL_SIZE_BITS=10
+AVRDUDE_OPTS = -q -q -D
+
 else
 ifeq (${TARGET}, atmega2560)
 BOARD_TAG = mega2560
 CPPFLAGS += -DNUM_MOTORS=7 -DFRAGMENTS_PER_MOTOR_BITS=4 -DBYTES_PER_FRAGMENT=16 -DSERIAL_SIZE_BITS=10
+AVRDUDE_OPTS = -q -q -D
+
 else
 ifeq (${TARGET}, atmega1281)
 BOARD_TAG = 1281
 ARDUINO_VAR_PATH = /usr/share/arduino/hardware/MegaCore/variants
 BOARDS_TXT = /usr/share/arduino/hardware/MegaCore/boards.txt
 CPPFLAGS += -DNUM_MOTORS=7 -DFRAGMENTS_PER_MOTOR_BITS=4 -DBYTES_PER_FRAGMENT=16 -DSERIAL_SIZE_BITS=10
+AVRDUDE_OPTS = -q -q -D
+
 else
 ifeq (${TARGET}, atmega644p)
 BOARD_TAG = atmega644p
 ARDUINO_VAR_PATH = /usr/share/arduino/hardware/sanguino/variants
 BOARDS_TXT = /usr/share/arduino/hardware/sanguino/boards.txt
 CPPFLAGS += -DNUM_MOTORS=4 -DFRAGMENTS_PER_MOTOR_BITS=3 -DBYTES_PER_FRAGMENT=8 -DSERIAL_SIZE_BITS=9 -DNO_DEBUG
+AVRDUDE_OPTS = -q -q -D
+
 else
 $(error Invalid TARGET)
 endif

--- a/server/server.py
+++ b/server/server.py
@@ -4,6 +4,7 @@
 # server.py - machine multiplexing for Franklin {{{
 # Copyright 2014-2016 Michigan Technological University
 # Copyright 2016 Bas Wijnen <wijnen@debian.org>
+# Copyright 2017 Lorin Edwin Parker <lorin.parker@hive13.org>
 # Author: Bas Wijnen <wijnen@debian.org>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -300,7 +301,7 @@ class Connection: # {{{
 		filename = fhs.read_data(os.path.join('firmware', boards[board]['build.mcu'] + os.extsep + 'hex'), opened = False)
 		if filename is None:
 			raise NotImplementedError('Firmware is not available')
-		return ('avrdude', '-q', '-q', '-p', boards[board]['build.mcu'], '-b', boards[board]['upload.speed'], '-c', boards[board]['upload.protocol'], '-P', port, '-U', 'flash:w:' + filename + ':i')
+		return ('avrdude', '-D', '-q', '-q', '-p', boards[board]['build.mcu'], '-C /etc/avrdude.conf', '-b', boards[board]['upload.speed'], '-c', boards[board]['upload.protocol'], '-P', port, '-U', 'flash:w:' + filename + ':i')
 	# }}}
 	def upload(self, port, board): # {{{
 		wake = (yield)


### PR DESCRIPTION
Made changes to:

/firmware/Makefile
/server/server.py

Firmware now builds and installs via "make upload",
Revised avrdude command in server.py to work there too. 

Verified firmware upload on Raspberry Pi and BBB/G --> Atmega2560 (ramps)

Remaining issues: In new UI, hardware tab:

I still do not see firmware selections in dropdown, and cannot upload from ui (just command line)

USB must be unplugged and plugged back in to be recognized and show up in ui. Still, no upload selections, just "detect"

So, the firmware will make and upload now, but I think the ui needs to be tweaked so dropdown shows upload options.

Is server not reading boards.txt file, perhaps? 
 
Lorin

P.S. I suck at git. I did not intend to make changes to root Makefile (although, I don't think a carriage return will hurt anything) -- git is sort of touchy, no? 